### PR TITLE
Check for existing (or not) role names

### DIFF
--- a/lib/awskeyring.rb
+++ b/lib/awskeyring.rb
@@ -302,4 +302,24 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
 
     account_name
   end
+
+  # Validate role exists
+  #
+  # @param [String] role_name the associated role name.
+  def self.role_exists(role_name)
+    Awskeyring::Validate.role_name(role_name)
+    raise 'Role does not exist' unless list_role_names.include?(role_name)
+
+    role_name
+  end
+
+  # Validate role does not exists
+  #
+  # @param [String] role_name the associated role name.
+  def self.role_not_exists(role_name)
+    Awskeyring::Validate.role_name(role_name)
+    raise 'Role already exists' if list_role_names.include?(role_name)
+
+    role_name
+  end
 end

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -185,7 +185,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   def add_role(role = nil)
     role = ask_check(
       existing: role, message: I18n.t('message.role'),
-      validator: Awskeyring::Validate.method(:role_name)
+      validator: Awskeyring.method(:role_not_exists)
     )
     arn = ask_check(
       existing: options[:arn], message: I18n.t('message.arn'),
@@ -222,7 +222,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   # remove a role
   def remove_role(role = nil)
     role = ask_check(
-      existing: role, message: I18n.t('message.role'), validator: Awskeyring::Validate.method(:role_name)
+      existing: role, message: I18n.t('message.role'), validator: Awskeyring.method(:role_exists)
     )
     Awskeyring.delete_role(role_name: role, message: I18n.t('message.delrole', role: role))
   end
@@ -268,7 +268,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     role ||= options[:role]
     if role
       role = ask_check(
-        existing: role, message: I18n.t('message.role'), validator: Awskeyring::Validate.method(:role_name)
+        existing: role, message: I18n.t('message.role'), validator: Awskeyring.method(:role_exists)
       )
     end
     code ||= options[:code]

--- a/spec/lib/awskeyring_command_more_spec.rb
+++ b/spec/lib/awskeyring_command_more_spec.rb
@@ -107,6 +107,7 @@ describe AwskeyringCommand do
       allow(Thor::LineEditor).to receive(:readline).and_return('invalid')
       allow(Time).to receive(:new).and_return(Time.parse('2011-07-11T19:55:29.611Z'))
       allow(Awskeyring).to receive(:account_exists).and_return('test')
+      allow(Awskeyring).to receive(:role_exists).and_return('role')
     end
 
     it 'tries to receive a new token' do
@@ -330,6 +331,7 @@ describe AwskeyringCommand do
     before do
       allow(Awskeyring).to receive(:add_role).and_return(nil)
       allow(Thor::LineEditor).to receive(:readline).and_return(bad_role_arn)
+      allow(Awskeyring).to receive(:role_not_exists).and_return('readonly')
     end
 
     it 'tries to add a valid role' do

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -114,6 +114,7 @@ describe AwskeyringCommand do
       allow(Time).to receive(:new).and_return(Time.parse('2011-07-11T19:55:29.611Z'))
       allow(Awskeyring::Awsapi).to receive(:region).and_return(nil)
       allow(Awskeyring).to receive(:account_exists).and_return('test')
+      allow(Awskeyring).to receive(:role_exists).and_return('test')
     end
 
     it 'removes an account' do

--- a/spec/lib/awskeyring_spec.rb
+++ b/spec/lib/awskeyring_spec.rb
@@ -230,5 +230,13 @@ describe Awskeyring do
     it 'invalidates an account name' do
       expect { awskeyring.account_not_exists('test') }.to raise_error('Account already exists')
     end
+
+    it 'validates a role name' do
+      expect { awskeyring.role_exists('test') }.not_to raise_error
+    end
+
+    it 'invalidates a role name' do
+      expect { awskeyring.role_not_exists('test') }.to raise_error('Role already exists')
+    end
   end
 end


### PR DESCRIPTION
Avoid role name clash by checking first.