### PR TITLE
Check for existing account keys and role arns

### DIFF
--- a/lib/awskeyring.rb
+++ b/lib/awskeyring.rb
@@ -87,6 +87,11 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
     load_keychain.generic_passwords
   end
 
+  # return an item by accout
+  private_class_method def self.item_by_account(account)
+    all_items.where(account: account).first
+  end
+
   # Add an account item
   #
   # @param [String] account The account name to create
@@ -308,6 +313,16 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
     account_name
   end
 
+  # Validate access key does not exists
+  #
+  # @param [String] access_key the associated access key.
+  def self.access_key_not_exists(access_key)
+    Awskeyring::Validate.access_key(access_key)
+    raise 'Access KEY already exists' if item_by_account(access_key)
+
+    access_key
+  end
+
   # Validate role exists
   #
   # @param [String] role_name the associated role name.
@@ -326,5 +341,15 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
     raise 'Role already exists' if list_role_names.include?(role_name)
 
     role_name
+  end
+
+  # Validate role arn not exists
+  #
+  # @param [String] role_arn the associated role arn.
+  def self.role_arn_not_exists(role_arn)
+    Awskeyring::Validate.role_arn(role_arn)
+    raise 'Role ARN already exists' if item_by_account(role_arn)
+
+    role_arn
   end
 end

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -149,7 +149,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
       existing: account, message: I18n.t('message.account'), validator: Awskeyring.method(:account_not_exists)
     )
     key = ask_check(
-      existing: options[:key], message: I18n.t('message.key'), validator: Awskeyring::Validate.method(:access_key)
+      existing: options[:key], message: I18n.t('message.key'), validator: Awskeyring.method(:access_key_not_exists)
     )
     secret = ask_check(
       existing: options[:secret], message: I18n.t('message.secret'),
@@ -181,7 +181,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
       limited_to: Awskeyring.list_account_names
     )
     key = ask_check(
-      existing: options[:key], message: I18n.t('message.key'), validator: Awskeyring::Validate.method(:access_key)
+      existing: options[:key], message: I18n.t('message.key'), validator: Awskeyring.method(:access_key_not_exists)
     )
     secret = ask_check(
       existing: options[:secret], message: I18n.t('message.secret'),
@@ -207,7 +207,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     )
     arn = ask_check(
       existing: options[:arn], message: I18n.t('message.arn'),
-      validator: Awskeyring::Validate.method(:role_arn)
+      validator: Awskeyring.method(:role_arn_not_exists)
     )
 
     Awskeyring.add_role(

--- a/spec/lib/awskeyring_command_more_spec.rb
+++ b/spec/lib/awskeyring_command_more_spec.rb
@@ -239,6 +239,7 @@ describe AwskeyringCommand do
       allow(Awskeyring).to receive(:account_not_exists).with('test').and_return('test')
       allow(Awskeyring).to receive(:account_exists).with('tested').and_return('tested')
       allow(Awskeyring).to receive(:list_account_names).and_return(['tested'])
+      allow(Awskeyring).to receive(:item_by_account).and_return(nil)
       allow(Awskeyring::Input).to receive(:read_secret).and_return(bad_secret_access_key)
       allow(Awskeyring).to receive(:list_role_names).and_return(['role'])
     end
@@ -295,6 +296,7 @@ describe AwskeyringCommand do
     before do
       allow(Thor::LineEditor).to receive(:readline).and_return(bad_mfa_arn)
       allow(Awskeyring).to receive(:account_not_exists).with('test').and_return('test')
+      allow(Awskeyring).to receive(:item_by_account).and_return(nil)
     end
 
     it 'tries to add an invalid mfa' do
@@ -312,6 +314,7 @@ describe AwskeyringCommand do
     before do
       allow(Thor::LineEditor).to receive(:readline).and_return(" #{access_key} \n")
       allow(Awskeyring::Input).to receive(:read_secret).and_return(" #{secret_access_key} \t")
+      allow(Awskeyring).to receive(:item_by_account).and_return(nil)
       allow(Awskeyring).to receive(:account_not_exists).with('test').and_return('test')
       allow(Awskeyring).to receive(:add_account).and_return(nil)
       allow(Awskeyring::Awsapi).to receive(:verify_cred)
@@ -336,6 +339,7 @@ describe AwskeyringCommand do
     before do
       allow(Awskeyring).to receive(:add_role).and_return(nil)
       allow(Thor::LineEditor).to receive(:readline).and_return(bad_role_arn)
+      allow(Awskeyring).to receive(:item_by_account).and_return(nil)
       allow(Awskeyring).to receive(:role_not_exists).and_return('readonly')
     end
 


### PR DESCRIPTION
Prevents error when adding duplicate keys and roles to the keychain.