### PR TITLE
Enhanced version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,15 @@ Rubycw/Rubycw:
   Exclude:
     - ./*.md
 
+Style/HashEachMethods:
+   Enabled: true
+
+Style/HashTransformKeys:
+   Enabled: true
+
+Style/HashTransformValues:
+   Enabled: true
+
 AllCops:
   Exclude:
     - bin/*

--- a/lib/awskeyring/version.rb
+++ b/lib/awskeyring/version.rb
@@ -1,8 +1,24 @@
 # frozen_string_literal: true
 
+require 'json'
+
+# Awskeyring Module,
+# Version const and query of latest.
 module Awskeyring
   # The Gem's version number
   VERSION = '1.2.0'
   # The Gem's homepage
   HOMEPAGE = 'https://github.com/servian/awskeyring'
+
+  # RubyGems Version url
+  GEM_VERSION_URL = 'https://rubygems.org/api/v1/versions/awskeyring/latest.json'
+
+  # Retrieve the latest version from RubyGems
+  #
+  def self.latest_version
+    uri       = URI(GEM_VERSION_URL)
+    request   = Net::HTTP.new(uri.host, uri.port)
+    request.use_ssl = true
+    JSON.parse(request.get(uri).body)['version']
+  end
 end

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -34,9 +34,13 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   end
 
   desc '--version, -v', I18n.t('__version.desc')
+  method_option 'no-remote', type: :boolean, aliases: '-r', desc: I18n.t('method_option.noremote'), default: false
   # print the version number
   def __version
     puts "Awskeyring v#{Awskeyring::VERSION}"
+    if !options['no-remote'] && Awskeyring::VERSION != Awskeyring.latest_version
+      puts "the latest version v#{Awskeyring.latest_version}"
+    end
     puts "Homepage #{Awskeyring::HOMEPAGE}"
   end
 

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -6,6 +6,10 @@ require_relative '../../lib/awskeyring_command'
 
 describe AwskeyringCommand do
   context 'when things are left to the defaults' do
+    let(:current_version) { Awskeyring::VERSION }
+    let(:latest_version) { '1.1.1' }
+    let(:home_page) { Awskeyring::HOMEPAGE }
+
     before do
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?)
@@ -13,6 +17,7 @@ describe AwskeyringCommand do
         .and_return(false)
       allow(Thor::LineEditor).to receive(:readline).and_return('test')
       allow(Awskeyring).to receive(:init_keychain)
+      allow(Awskeyring).to receive(:latest_version).and_return(latest_version)
     end
 
     it 'outputs help text' do
@@ -23,8 +28,14 @@ describe AwskeyringCommand do
     end
 
     it 'returns the version number' do
+      expect(Awskeyring).not_to have_received(:latest_version)
+      expect { described_class.start(%w[__version -r]) }
+        .to output("Awskeyring v#{current_version}\nHomepage #{home_page}\n").to_stdout
+    end
+
+    it 'returns the version number with checks online' do
       expect { described_class.start(%w[__version]) }
-        .to output(/\d+\.\d+\.\d+/).to_stdout
+        .to output(/latest version v1\.1\.1/).to_stdout
     end
 
     it 'prints autocomplete help text' do

--- a/spec/lib/awskeyring_spec.rb
+++ b/spec/lib/awskeyring_spec.rb
@@ -277,4 +277,24 @@ describe Awskeyring do
       )
     end
   end
+
+  context 'when we try to find the latest version' do
+    let(:net_http) { instance_double(Net::HTTP) }
+
+    before do
+      allow(Net::HTTP).to receive(:new).and_return(net_http)
+      allow(net_http).to receive(:get)
+        .and_return(
+          instance_double(
+            'HashMap',
+            body: '{"version":"1.2.3"}'
+          )
+        )
+      allow(net_http).to receive(:use_ssl=)
+    end
+
+    it 'return the version number' do
+      expect(awskeyring.latest_version).to eq('1.2.3')
+    end
+  end
 end


### PR DESCRIPTION
- Fetches "Latest Release" version from GitHub API - points to repo servian/awskeyring
- Compares with installed version on machine
- If version is out of date and response == 200 (then highlight newer release available)
- If version == current release highlight that client is up to date
- If API is not reachable that means the response.code (for API status code) will not be set and therefore will default to not identifying whether or not the version is up-to-date 

