### PR TITLE
Markdown linting changes and removed Rubocop-MD.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Ran Command '...'
 2. Typed '....'
 3. See error
@@ -20,9 +21,10 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Desktop (please complete the following information):**
- - macOS version: [e.g. Majave]
- - Ruby version [e.g. 2.3.7p456]
- - Awskeyring Version [e.g. 1.0.1]
+
+- macOS version: [e.g. Majave]
+- Ruby version [e.g. 2.3.7p456]
+- Awskeyring Version [e.g. 1.0.1]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,11 @@
 # Description
 
-Please include a summary of the change and which issue is fixed or feature is being added. Please also include relevant motivation and context. Please also delete this text.
+Please include a summary of the change and which issue is fixed or feature is being added. Please also include relevant
+motivation and context. Please also delete this text.
 
 Fixes # (issue) if applicable
 
-# did you run the Tests?
+## Did you run the Tests?
 
 - [ ] Rubocop
 - [ ] Rspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,4 @@
 ---
-require:
-  - rubocop-md
-  - rubocop-performance
-  - rubocop-rake
-  - rubocop-rspec
-  - rubocop-rubycw
-
 Layout/LineLength:
   Max: 120
 
@@ -29,10 +22,6 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Enabled: false
-
-Rubycw/Rubycw:
-  Exclude:
-    - ./*.md
 
 Style/HashEachMethods:
   Enabled: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ A friendly `README.md` written for many audiences.
 
 The [wiki].
 
-###  API documentation
+### API documentation
 
 API documentation is written as [YARD] docblocks in the Ruby code.
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ group :development do
   gem 'ronn'
   gem 'rspec'
   gem 'rubocop'
-  gem 'rubocop-md'
   gem 'rubocop-performance'
   gem 'rubocop-rake'
   gem 'rubocop-rspec'

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Now your keys are stored safely in the macOS keychain. To print environment vari
 
     awskeyring env personal-aws
 
-Alternatively you can create a profile using the credential_process config variable. See the [AWS CLI Config docs](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#cli-aws-help-config-vars) for more details on this config option.
+Alternatively you can create a profile using the credential_process config variable. See the
+[AWS CLI Config docs](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#cli-aws-help-config-vars) for
+more details on this config option.
 
     [profile personal]
     region = us-west-1
@@ -87,22 +89,28 @@ To set your environment easily the following bash function helps:
 
 ## Development
 
-After checking out the repo, run `bundle update` to install dependencies. Then, run `bundle exec rake` to run the tests. Run `bundle exec awskeyring` to use the gem in this directory, ignoring other installed copies of this gem. Awskeyring is tested against the last two versions of Ruby shipped with macOS.
+After checking out the repo, run `bundle update` to install dependencies. Then, run `bundle exec rake` to run the
+tests. Run `bundle exec awskeyring` to use the gem in this directory, ignoring other installed copies of this gem.
+Awskeyring is tested against the last two versions of Ruby shipped with macOS.
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Security
 
-If you believe you have found a security issue in Awskeyring, please responsibly disclose by contacting me at [tristan@vibrato.com.au](mailto:tristan@vibrato.com.au). Awskeyring is a Ruby script and as such Ruby is whitelisted to access your "awskeyring" keychain. Use a strong password and keep the unlock time short.
+If you believe you have found a security issue in Awskeyring, please responsibly disclose by contacting me at
+[tristan@vibrato.com.au](mailto:tristan@vibrato.com.au). Awskeyring is a Ruby script and as such Ruby is whitelisted
+to access your "awskeyring" keychain. Use a strong password and keep the unlock time short.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/servian/awskeyring. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](https://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at [https://github.com/servian/awskeyring](https://github.com/servian/awskeyring).
+This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to
+the [Contributor Covenant](https://contributor-covenant.org) code of conduct.
 
 ### Contributors
 
- * Tristan [tristanmorgan](https://github.com/tristanmorgan)
- * Adam Sir [AzySir](https://github.com/AzySir)
+* Tristan [tristanmorgan](https://github.com/tristanmorgan)
+* Adam Sir [AzySir](https://github.com/AzySir)
 
 ## License
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,10 @@ end
 
 RuboCop::RakeTask.new do |rubocop|
   rubocop.options = ['-D']
+  rubocop.requires << 'rubocop-performance'
+  rubocop.requires << 'rubocop-rake'
+  rubocop.requires << 'rubocop-rspec'
+  rubocop.requires << 'rubocop-rubycw'
 end
 
 RSpec::Core::RakeTask.new(:spec)

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,10 +1,10 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "February 2020" "" ""
+.TH "AWSKEYRING" "5" "March 2020" "" ""
 .
 .SH "NAME"
-\fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain\.
+\fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain
 .
 .SH "SYNOPSIS"
 awskeyring COMMAND [ACCOUNT|ROLE] [OPTIONS]
@@ -13,7 +13,7 @@ awskeyring COMMAND [ACCOUNT|ROLE] [OPTIONS]
 awskeyring help COMMAND
 .
 .SH "DESCRIPTION"
-The Awskeyring utility stores and manages AWS access keys and provides the facailty to generate access tokens with combinations of assumed roles and multi\-factor\-authentication codes\. It includes autocompletion features and multiple validation checks for input parsing\. It also includes the ability for the AWS CLI to call it directly to provide authentication\.
+The Awskeyring utility stores and manages AWS access keys and provides the facility to generate access tokens with combinations of assumed roles and multi\-factor\-authentication codes\. It includes autocompletion features and multiple validation checks for input parsing\. It also includes the ability for the AWS CLI to call it directly to provide authentication\.
 .
 .P
 The commands are as follows:

--- a/man/awskeyring.5.ronn
+++ b/man/awskeyring.5.ronn
@@ -1,4 +1,4 @@
-# Awskeyring -- is a small tool to manage AWS account keys in the macOS Keychain.
+# Awskeyring -- is a small tool to manage AWS account keys in the macOS Keychain
 
 ## SYNOPSIS
 
@@ -8,81 +8,84 @@ awskeyring help COMMAND
 
 ## DESCRIPTION
 
-The Awskeyring utility stores and manages AWS access keys and provides the facailty to generate access tokens with combinations of assumed roles and multi-factor-authentication codes. It includes autocompletion features and multiple validation checks for input parsing. It also includes the ability for the AWS CLI to call it directly to provide authentication.
+The Awskeyring utility stores and manages AWS access keys and provides the facility to generate access tokens with
+combinations of assumed roles and multi-factor-authentication codes. It includes autocompletion features and multiple
+validation checks for input parsing. It also includes the ability for the AWS CLI to call it directly to provide authentication.
 
 The commands are as follows:
 
-  *  --version, -v:
+* --version, -v:
 
     Prints the version
 
-  *  add ACCOUNT:
+* add ACCOUNT:
 
     Adds an ACCOUNT to the keyring
 
-  *  add-role ROLE:
+* add-role ROLE:
 
     Adds a ROLE to the keyring
 
-*  console ACCOUNT:
+* console ACCOUNT:
 
     Open the AWS Console for the ACCOUNT
 
-*  env ACCOUNT:
+* env ACCOUNT:
 
     Outputs bourne shell environment exports for an ACCOUNT
 
-*  exec ACCOUNT command...:
+* exec ACCOUNT command...:
 
     Execute a COMMAND with the environment set for an ACCOUNT
 
-*  help [COMMAND]:
+* help [COMMAND]:
 
     Describe available commands or one specific command
 
-*  initialise:
+* initialise:
 
     Initialises a new KEYCHAIN
 
-*  json ACCOUNT:
+* json ACCOUNT:
 
     Outputs AWS CLI compatible JSON for an ACCOUNT
 
-*  list:
+* list:
 
     Prints a list of accounts in the keyring
 
-*  list-role:
+* list-role:
 
     Prints a list of roles in the keyring
 
-*  remove ACCOUNT:
+* remove ACCOUNT:
 
     Removes an ACCOUNT from the keyring
 
-*  remove-role ROLE:
+* remove-role ROLE:
 
     Removes a ROLE from the keyring
 
-*  remove-token ACCOUNT:
+* remove-token ACCOUNT:
 
     Removes a token for ACCOUNT from the keyring
 
-*  rotate ACCOUNT:
+* rotate ACCOUNT:
 
     Rotate access keys for an ACCOUNT
 
-*  token ACCOUNT [ROLE] [MFA]:
+* token ACCOUNT [ROLE] [MFA]:
 
     Create an STS Token from a ROLE or an MFA code
 
-*  update ACCOUNT:
+* update ACCOUNT:
 
     Updates an ACCOUNT in the keyring
 
 ## ENVIRONMENT
 
-The AWS_DEFAULT_REGION environment variable will be used for AWS API calls where specified or fall back to us-east-1 when not.
+The AWS_DEFAULT_REGION environment variable will be used for AWS API calls where specified or fall back to us-east-1
+when not.
 
 ## EXIT STATUS
 
@@ -113,7 +116,9 @@ like [HashiCorp Vault](https://vaultproject.io/).
 
 ## SECURITY
 
-If you believe you have found a security issue in Awskeyring, please responsibly disclose by contacting me at [tristan@vibrato.com.au](mailto:tristan@vibrato.com.au). Awskeyring is a Ruby script and as such Ruby is whitelisted to access your "awskeyring" keychain. Use a strong password and keep the unlock time short.
+If you believe you have found a security issue in Awskeyring, please responsibly disclose by contacting me at
+[tristan@vibrato.com.au](mailto:tristan@vibrato.com.au). Awskeyring is a Ruby script and as such Ruby is whitelisted to
+access your "awskeyring" keychain. Use a strong password and keep the unlock time short.
 
 ## AUTHOR
 
@@ -121,8 +126,8 @@ Tristan Morgan <tristan@vibrato.com.au> is the maintainer of Awskeyring.
 
 ## CONTRIBUTORS
 
- * Tristan [tristanmorgan](https://github.com/tristanmorgan)
- * Adam Sir [AzySir](https://github.com/AzySir)
+* Tristan [tristanmorgan](https://github.com/tristanmorgan)
+* Adam Sir [AzySir](https://github.com/AzySir)
 
 ## LICENSE
 

--- a/spec/lib/awskeyring/awsapi_spec.rb
+++ b/spec/lib/awskeyring/awsapi_spec.rb
@@ -321,7 +321,7 @@ describe Awskeyring::Awsapi do
     it 'calls the rotate method and fails' do
       expect do
         awsapi.rotate(account: account, key: key, secret: secret, key_message: key_message)
-      end.to raise_error(SystemExit).and output(/# You have two access keys for account test/).to_stderr
+      end.to raise_error.and output(/# You have two access keys for account test/).to_stderr
 
       expect(iam_client).not_to have_received(:create_access_key)
       expect(iam_client).not_to have_received(:delete_access_key)

--- a/spec/lib/awskeyring_command_more_spec.rb
+++ b/spec/lib/awskeyring_command_more_spec.rb
@@ -218,7 +218,7 @@ describe AwskeyringCommand do
     it 'tries to receive a new token with an invalid MFA' do
       expect do
         described_class.start(%w[token test -c invalid])
-      end.to raise_error(SystemExit).and output(/Invalid MFA CODE/).to_stderr
+      end.to raise_error.and output(/Invalid MFA CODE/).to_stderr
     end
   end
 
@@ -278,13 +278,13 @@ describe AwskeyringCommand do
     it 'tries to add an invalid access_key' do
       expect do
         described_class.start(['add', 'test', '-k', bad_access_key, '-s', secret_access_key, '-m', mfa_arn])
-      end.to raise_error(SystemExit).and output(/Invalid Access Key/).to_stderr
+      end.to raise_error.and output(/Invalid Access Key/).to_stderr
     end
 
     it 'tries to add an invalid secret' do
       expect do
         described_class.start(['add', 'test', '-k', access_key, '-s', bad_secret_access_key, '-m', mfa_arn])
-      end.to raise_error(SystemExit).and output(/Secret Access Key is not 40 chars/).to_stderr
+      end.to raise_error.and output(/Secret Access Key is not 40 chars/).to_stderr
     end
   end
 
@@ -302,7 +302,7 @@ describe AwskeyringCommand do
     it 'tries to add an invalid mfa' do
       expect do
         described_class.start(['add', 'test', '-k', access_key, '-s', secret_access_key, '-m', bad_mfa_arn])
-      end.to raise_error(SystemExit).and output(/Invalid MFA ARN/).to_stderr
+      end.to raise_error.and output(/Invalid MFA ARN/).to_stderr
     end
   end
 
@@ -352,7 +352,7 @@ describe AwskeyringCommand do
     it 'tries to add an invalid role arn' do
       expect do
         described_class.start(['add-role', 'readonly', '-a', bad_role_arn])
-      end.to raise_error(SystemExit).and output(/Invalid Role ARN/).to_stderr
+      end.to raise_error.and output(/Invalid Role ARN/).to_stderr
     end
   end
 
@@ -448,7 +448,7 @@ describe AwskeyringCommand do
     it 'calls the rotate method and fails' do
       expect do
         described_class.start(%w[rotate test])
-      end.to raise_error(SystemExit).and output(/# You have two access keys for account test/).to_stderr
+      end.to raise_error.and output(/# You have two access keys for account test/).to_stderr
 
       expect(Awskeyring).to have_received(:get_valid_creds).with(account: 'test', no_token: true)
       expect(Awskeyring).not_to have_received(:update_account)

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -39,17 +39,17 @@ describe AwskeyringCommand do
     end
 
     it 'prints autocomplete help text' do
-      expect { described_class.start(%w[awskeyring one two]) }.to raise_error(SystemExit)
+      expect { described_class.start(%w[awskeyring one two]) }.to raise_error
         .and output(%r{enable autocomplete with 'complete -C \/.+\/\w+ \w+'}).to_stderr
     end
 
     it 'tells you that you must init the keychain' do
-      expect { described_class.start(%w[list]) }.to raise_error(SystemExit)
+      expect { described_class.start(%w[list]) }.to raise_error
         .and output(/Config missing, run `\w+ initialise` to recreate./).to_stderr
     end
 
     it 'tells you it could not find the command test' do
-      expect { described_class.start(%w[test]) }.to raise_error(SystemExit)
+      expect { described_class.start(%w[test]) }.to raise_error
         .and output(/Could not find command "test"./).to_stderr
     end
 
@@ -281,7 +281,7 @@ unset AWS_SESSION_TOKEN
     it 'warns about a missing external command' do
       expect do
         described_class.start(%w[exec test])
-      end.to raise_error(SystemExit).and output(/COMMAND not provided/).to_stderr
+      end.to raise_error.and output(/COMMAND not provided/).to_stderr
       expect(Process).not_to have_received(:spawn)
     end
   end


### PR DESCRIPTION
# Description

Ran linting on the Markdown files with [markdownlint](https://github.com/markdownlint/markdownlint) and found the RuboCop-MD wasn't doing what In expected so removed it. Also tweaked the spec files with [Transpec](https://github.com/yujinakayama/transpec). 

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
