### PR TITLE
Fix I18n message load when used as a library.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,16 +28,13 @@ desc 'Check filemode bits'
 task :filemode do
   files = Set.new(`git ls-files -z`.split("\x0"))
   dirs = Set.new(files.map { |file| File.dirname(file) })
-  failure = false
+  failure = []
   files.merge(dirs).each do |file|
     mode = File.stat(file).mode
     print '.'
-    if (mode & 0x7) != (mode >> 3 & 0x7)
-      puts file
-      failure = true
-    end
+    failure << file if (mode & 0x7) != (mode >> 3 & 0x7)
   end
-  abort 'Error: Incorrect file mode found' if failure
+  abort "\nError: Incorrect file mode found\n#{failure.join("\n")}" unless failure.empty?
   print "\n"
 end
 

--- a/lib/awskeyring.rb
+++ b/lib/awskeyring.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'i18n'
 require 'json'
 require 'keychain'
 require 'awskeyring/validate'
@@ -7,6 +8,9 @@ require 'awskeyring/validate'
 # Awskeyring Module,
 # gives you an interface to access keychains and items.
 module Awskeyring # rubocop:disable Metrics/ModuleLength
+  I18n.load_path = Dir.glob(File.join(File.realpath(__dir__), '..', 'i18n', '*.{yml,yaml}'))
+  I18n.backend.load_translations
+
   # Default rpeferences fole path
   PREFS_FILE = (File.expand_path '~/.awskeyring').freeze
   # Prefix for Roles


### PR DESCRIPTION
# Description

Fix for when the gem is included in another ruby project and not used through the CLI, the translations path didn't seem to load.
Plus tweaked the error message on the filemode test.

## Did you run the Tests?

- [X] Rubocop
- [X] Rspec
- [X] Filemode
- [X] Yard

