### PR TITLE
Change email references from Vibrato to Servian

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [tristan@vibrato.com.au]. All
+reported by contacting the project team at [tristan.morgan@servian.com](mailto:tristan.morgan@servian.com). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -68,6 +68,6 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+available [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
 
 [homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 ## Security
 
 If you believe you have found a security issue in Awskeyring, please responsibly disclose by contacting me at
-[tristan@vibrato.com.au](mailto:tristan@vibrato.com.au). Awskeyring is a Ruby script and as such Ruby is whitelisted
+[tristan.morgan@servian.com](mailto:tristan.morgan@servian.com). Awskeyring is a Ruby script and as such Ruby is whitelisted
 to access your "awskeyring" keychain. Use a strong password and keep the unlock time short.
 
 ## Contributing

--- a/awskeyring.gemspec
+++ b/awskeyring.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'awskeyring'
   spec.version       = Awskeyring::VERSION
   spec.authors       = ['Tristan Morgan']
-  spec.email         = ['tristan@vibrato.com.au']
+  spec.email         = ['tristan.morgan@servian.com']
 
   spec.summary       = 'Manages AWS credentials in the macOS keychain'
   spec.description   = 'Manages AWS credentials in the macOS keychain'

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "March 2020" "" ""
+.TH "AWSKEYRING" "5" "April 2020" "" ""
 .
 .SH "NAME"
 \fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain
@@ -169,10 +169,10 @@ awskeyring env personal\-aws
 The motivation of this application is to provide a local secure store of AWS credentials using specifically in the macOS Keychain, to have them easily accessed from the Terminal, and to provide useful functions like assuming roles and opening the AWS Console from the cli\. For Enterprise environments there are better suited tools to use like HashiCorp Vault \fIhttps://vaultproject\.io/\fR\.
 .
 .SH "SECURITY"
-If you believe you have found a security issue in Awskeyring, please responsibly disclose by contacting me at \fItristan@vibrato\.com\.au\fR\. Awskeyring is a Ruby script and as such Ruby is whitelisted to access your "awskeyring" keychain\. Use a strong password and keep the unlock time short\.
+If you believe you have found a security issue in Awskeyring, please responsibly disclose by contacting me at \fItristan\.morgan@servian\.com\fR\. Awskeyring is a Ruby script and as such Ruby is whitelisted to access your "awskeyring" keychain\. Use a strong password and keep the unlock time short\.
 .
 .SH "AUTHOR"
-Tristan Morgan \fItristan@vibrato\.com\.au\fR is the maintainer of Awskeyring\.
+Tristan Morgan \fItristan\.morgan@servian\.com\fR is the maintainer of Awskeyring\.
 .
 .SH "CONTRIBUTORS"
 .

--- a/man/awskeyring.5.ronn
+++ b/man/awskeyring.5.ronn
@@ -117,12 +117,12 @@ like [HashiCorp Vault](https://vaultproject.io/).
 ## SECURITY
 
 If you believe you have found a security issue in Awskeyring, please responsibly disclose by contacting me at
-[tristan@vibrato.com.au](mailto:tristan@vibrato.com.au). Awskeyring is a Ruby script and as such Ruby is whitelisted to
+[tristan.morgan@servian.com](mailto:tristan.morgan@servian.com). Awskeyring is a Ruby script and as such Ruby is whitelisted to
 access your "awskeyring" keychain. Use a strong password and keep the unlock time short.
 
 ## AUTHOR
 
-Tristan Morgan <tristan@vibrato.com.au> is the maintainer of Awskeyring.
+Tristan Morgan <tristan.morgan@servian.com> is the maintainer of Awskeyring.
 
 ## CONTRIBUTORS
 

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -61,7 +61,7 @@ describe AwskeyringCommand do
 
   context 'when accounts and roles are set' do
     before do
-      allow(Awskeyring).to receive(:list_account_names).and_return(%w[company personal vibrato])
+      allow(Awskeyring).to receive(:list_account_names).and_return(%w[company personal servian])
       allow(Awskeyring).to receive(:list_role_names).and_return(%w[admin minion readonly])
       allow(Awskeyring).to receive(:list_role_names_plus)
         .and_return(%W[admin\tarn1 minion\tarn2 readonly\tarn3])
@@ -70,7 +70,7 @@ describe AwskeyringCommand do
 
     it 'list keychain items' do
       expect { described_class.start(%w[list]) }
-        .to output("company\npersonal\nvibrato\n").to_stdout
+        .to output("company\npersonal\nservian\n").to_stdout
     end
 
     it 'list keychain roles' do
@@ -84,15 +84,15 @@ describe AwskeyringCommand do
     end
 
     it 'lists accounts with autocomplete' do
-      ENV['COMP_LINE'] = 'awskeyring token vib'
-      expect { described_class.start(%w[awskeyring vib token]) }
-        .to output("vibrato\n").to_stdout
+      ENV['COMP_LINE'] = 'awskeyring token ser'
+      expect { described_class.start(%w[awskeyring ser token]) }
+        .to output("servian\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
 
     it 'lists roles with autocomplete' do
-      ENV['COMP_LINE'] = 'awskeyring token vibrato min'
-      expect { described_class.start(%w[awskeyring min vibrato]) }
+      ENV['COMP_LINE'] = 'awskeyring token servian min'
+      expect { described_class.start(%w[awskeyring min servian]) }
         .to output("minion\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
@@ -105,14 +105,14 @@ describe AwskeyringCommand do
     end
 
     it 'lists flags with autocomplete' do
-      ENV['COMP_LINE'] = 'awskeyring token vibrato minion --dura'
+      ENV['COMP_LINE'] = 'awskeyring token servian minion --dura'
       expect { described_class.start(%w[awskeyring --dura minion]) }
         .to output("--duration\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
 
     it 'lists console paths with autocomplete' do
-      ENV['COMP_LINE'] = 'awskeyring console vibrato --path cloud'
+      ENV['COMP_LINE'] = 'awskeyring console servian --path cloud'
       expect { described_class.start(%w[awskeyring cloud --path]) }
         .to output("cloudformation\n").to_stdout
       ENV['COMP_LINE'] = nil


### PR DESCRIPTION
# Description

Update references from Vibrato with Servian. (Note: both addresses are still valid)

Supersedes #62

## Did you run the Tests?

- [X] Rubocop
- [X] Rspec
- [X] Filemode
- [X] Yard
