### PR TITLE
Import Keys and Tokens from shared credentials files.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,4 @@
 ---
-Layout/LineLength:
-  Max: 120
-
 Metrics/MethodLength:
   Max: 16
 
@@ -11,11 +8,6 @@ Metrics/BlockLength:
 
 Metrics/AbcSize:
   Max: 20
-
-Bundler/GemComment:
-  Enabled: false
-  Include:
-    - Gemfile
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The CLI is using [Thor](http://whatisthor.com) with help provided interactively.
       awskeyring env ACCOUNT                 # Outputs bourne shell environment exports for an ACCOUNT
       awskeyring exec ACCOUNT command...     # Execute a COMMAND with the environment set for an ACCOUNT
       awskeyring help [COMMAND]              # Describe available commands or one specific command
+      awskeyring import ACCOUNT              # Import an ACCOUNT to the keyring from ~/.aws/credentials
       awskeyring initialise                  # Initialises a new KEYCHAIN
       awskeyring json ACCOUNT                # Outputs AWS CLI compatible JSON for an ACCOUNT
       awskeyring list                        # Prints a list of accounts in the keyring

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -14,6 +14,8 @@ en:
     desc: Outputs bourne shell environment exports for an ACCOUNT
   exec:
     desc: Execute a COMMAND with the environment set for an ACCOUNT
+  import:
+    desc: Import an ACCOUNT to the keyring from ~/.aws/credentials
   initialise:
     desc: Initialises a new KEYCHAIN
   json:

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -122,6 +122,42 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     )
   end
 
+  desc 'import ACCOUNT', I18n.t('import.desc')
+  method_option 'no-remote', type: :boolean, aliases: '-r', desc: I18n.t('method_option.noremote'), default: false
+  # Import an Account
+  def import(account = nil) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    account = ask_check(
+      existing: account, message: I18n.t('message.account'), validator: Awskeyring.method(:account_not_exists)
+    )
+    new_creds = Awskeyring::Awsapi.get_credentials_from_file(account: account)
+    unless options['no-remote']
+      Awskeyring::Awsapi.verify_cred(
+        key: new_creds[:key],
+        secret: new_creds[:secret],
+        token: new_creds[:token]
+      )
+    end
+    if new_creds[:token].nil?
+      Awskeyring.add_account(
+        account: new_creds[:account],
+        key: new_creds[:key],
+        secret: new_creds[:secret],
+        mfa: ''
+      )
+      puts I18n.t('message.addaccount', account: account)
+    else
+      Awskeyring.add_token(
+        account: new_creds[:account],
+        key: new_creds[:key],
+        secret: new_creds[:secret],
+        token: new_creds[:token],
+        expiry: new_creds[:expiry].to_i.to_s,
+        role: nil
+      )
+      puts I18n.t('message.addtoken', account: account, time: Time.at(new_creds[:expiry].to_i))
+    end
+  end
+
   desc 'exec ACCOUNT command...', I18n.t('exec.desc')
   method_option 'no-token', type: :boolean, aliases: '-n', desc: I18n.t('method_option.notoken'), default: false
   # execute an external command with env set
@@ -163,7 +199,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
       existing: options[:mfa], message: I18n.t('message.mfa'),
       flags: 'optional', validator: Awskeyring::Validate.method(:mfa_arn)
     )
-    Awskeyring::Awsapi.verify_cred(key: key, secret: secret) unless options['no-remote']
+    Awskeyring::Awsapi.verify_cred(key: key, secret: secret, token: nil) unless options['no-remote']
     Awskeyring.add_account(
       account: account,
       key: key,
@@ -235,8 +271,8 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   # remove a session token
   def remove_token(account = nil)
     account = ask_check(
-      existing: account, message: I18n.t('message.account'), validator: Awskeyring.method(:account_exists),
-      limited_to: Awskeyring.list_account_names
+      existing: account, message: I18n.t('message.account'), validator: Awskeyring.method(:token_exists),
+      limited_to: Awskeyring.list_token_names
     )
     Awskeyring.delete_token(account: account, message: I18n.t('message.deltoken', account: account))
   end

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -451,6 +451,8 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
       comp_len = 2
     when '--path', '-p'
       comp_len = 4
+    when 'remove-token', 'rmt'
+      comp_len = 5
     end
 
     [curr, comp_len, sub_cmd]
@@ -466,7 +468,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     self.class.map[sub_cmd].to_s
   end
 
-  def print_auto_resp(curr, len, sub_cmd)
+  def print_auto_resp(curr, len, sub_cmd) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
     list = []
     case len
     when 0
@@ -479,6 +481,8 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
       list = list_arguments(command: sub_cmd)
     when 4
       list = Awskeyring.list_console_path
+    when 5
+      list = Awskeyring.list_token_names
     else
       exit 1
     end

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "April 2020" "" ""
+.TH "AWSKEYRING" "5" "June 2020" "" ""
 .
 .SH "NAME"
 \fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain
@@ -59,6 +59,12 @@ help [COMMAND]:
 .
 .IP
 Describe available commands or one specific command
+.
+.TP
+import:
+.
+.IP
+Import an ACCOUNT to the keyring from ~/\.aws/credentials
 .
 .TP
 initialise:

--- a/man/awskeyring.5.ronn
+++ b/man/awskeyring.5.ronn
@@ -42,6 +42,10 @@ The commands are as follows:
 
     Describe available commands or one specific command
 
+* import:
+
+    Import an ACCOUNT to the keyring from ~/.aws/credentials
+
 * initialise:
 
     Initialises a new KEYCHAIN

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -62,6 +62,7 @@ describe AwskeyringCommand do
   context 'when accounts and roles are set' do
     before do
       allow(Awskeyring).to receive(:list_account_names).and_return(%w[company personal servian])
+      allow(Awskeyring).to receive(:list_token_names).and_return(%w[personal servian])
       allow(Awskeyring).to receive(:list_role_names).and_return(%w[admin minion readonly])
       allow(Awskeyring).to receive(:list_role_names_plus)
         .and_return(%W[admin\tarn1 minion\tarn2 readonly\tarn3])
@@ -115,6 +116,13 @@ describe AwskeyringCommand do
       ENV['COMP_LINE'] = 'awskeyring console servian --path cloud'
       expect { described_class.start(%w[awskeyring cloud --path]) }
         .to output("cloudformation\n").to_stdout
+      ENV['COMP_LINE'] = nil
+    end
+
+    it 'lists token names with autocomplete' do
+      ENV['COMP_LINE'] = 'awskeyring remove-token ser'
+      expect { described_class.start(%w[awskeyring ser remove-token]) }
+        .to output("servian\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
   end

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -218,12 +218,14 @@ unset AWS_SESSION_TOKEN
       allow(Process).to receive(:wait).exactly(1).with(8888)
       allow(Time).to receive(:new).and_return(Time.parse('2011-07-11T19:55:29.611Z'))
       allow(Awskeyring).to receive(:account_exists).and_return('test')
+      allow(Awskeyring).to receive(:token_exists).and_return('test')
       allow(Awskeyring).to receive(:list_account_names).and_return(['test'])
+      allow(Awskeyring).to receive(:list_token_names).and_return(['test'])
     end
 
     it 'removes a token' do
       described_class.start(%w[remove-token test])
-      expect(Awskeyring).to have_received(:account_exists).with('test')
+      expect(Awskeyring).to have_received(:token_exists).with('test')
       expect(Awskeyring).to have_received(:delete_token)
         .with(account: 'test', message: '# Removing token for account test')
     end

--- a/spec/lib/awskeyring_spec.rb
+++ b/spec/lib/awskeyring_spec.rb
@@ -190,7 +190,7 @@ describe Awskeyring do
       allow(all_list).to receive(:where).with(label: 'session-token test').and_return([session_token])
       allow(session_key).to receive(:delete)
       allow(session_token).to receive(:delete)
-      allow(Time).to receive(:now).and_return(Time.parse('2016-12-01T22:20:02Z'))
+      allow(Time).to receive(:new).and_return(Time.parse('2016-12-01T22:20:02Z'))
     end
 
     it 'returns a hash with the creds and token' do
@@ -235,6 +235,10 @@ describe Awskeyring do
       expect { awskeyring.account_not_exists('test') }.to raise_error('Account already exists')
     end
 
+    it 'validates an token name' do
+      expect { awskeyring.token_exists('test') }.not_to raise_error
+    end
+
     it 'invalidates an access key' do
       expect { awskeyring.access_key_not_exists('test') }.to raise_error('Invalid Access Key')
     end
@@ -245,6 +249,12 @@ describe Awskeyring do
 
     it 'lists all accounts' do
       expect(awskeyring.list_account_names).to eq(
+        ['test']
+      )
+    end
+
+    it 'lists all tokens' do
+      expect(awskeyring.list_token_names).to eq(
         ['test']
       )
     end


### PR DESCRIPTION
# Description

Adds a feature to import Keys and Tokens from shared credentials files. it can help in situations where an external tool does a SAML authentication and writes the credentials to the standard files (~/.aws/credentials) and you don't want to store sensitive information un-encrypted on disk. 

Includes Autocomplete for tokens and allows a token to be imported without the long lived key being available.

## Did you run the Tests?

- [x] Rubocop
- [X] Rspec
- [X] Filemode
- [X] Yard
