### PR TITLE
No-Bundle env changes for exec.

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -44,6 +44,7 @@ en:
     key: 'AWS account key id.'
     keychain: 'Name of KEYCHAIN to initialise.'
     mfa: 'AWS virtual mfa arn.'
+    nobundle: 'Unset Bundler environment variables.'
     noopen: 'Do not open the url.'
     notoken: 'Do not use saved token.'
     noremote: 'Do not validate with remote api.'

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -280,12 +280,28 @@ unset AWS_SESSION_TOKEN
     end
 
     it 'runs an external command' do
+      ENV['BUNDLER_ORIG_TEST_ENV'] = 'BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL'
+      ENV['TEST_ENV'] = 'CHANGED'
       described_class.start(%w[exec test test-exec with params])
       expect(Process).to have_received(:spawn).exactly(1).with(
         env_vars,
         'test-exec with params'
       )
       expect(Awskeyring).to have_received(:get_valid_creds).with(account: 'test', no_token: false)
+      expect(ENV['BUNDLER_ORIG_TEST_ENV']).to eq('BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL')
+      expect(ENV['TEST_ENV']).to eq('CHANGED')
+    end
+
+    it 'runs an external command and clears bundle' do
+      ENV['BUNDLER_ORIG_TEST_ENV'] = 'BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL'
+      ENV['TEST_ENV'] = 'CHANGED'
+      described_class.start(%w[exec test --no-bundle test-exec with params])
+      expect(Process).to have_received(:spawn).exactly(1).with(
+        env_vars,
+        'test-exec with params'
+      )
+      expect(Awskeyring).to have_received(:get_valid_creds).with(account: 'test', no_token: false)
+      expect(ENV['TEST_ENV']).to eq(nil)
     end
 
     it 'warns about a missing external command' do


### PR DESCRIPTION
# Description

Adds an option to the exec command to revert the environment variables set by Bundler. This mostly affects the Gem environment and path. It's optional so not a breaking change.

Fixes an issue (not officially reported) where sometime people using home-brew would experience applications missing/not-working?

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
