### PR TITLE
Add SimpleCov reports.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,6 @@ group :development do
   gem 'rubocop-rake'
   gem 'rubocop-rspec'
   gem 'rubocop-rubycw'
+  gem 'simplecov'
   gem 'yard'
 end

--- a/spec/lib/awskeyring_spec.rb
+++ b/spec/lib/awskeyring_spec.rb
@@ -6,11 +6,36 @@ describe Awskeyring do
   subject(:awskeyring) { described_class }
 
   context 'when there is no config file' do
+    let(:write_success) { 'great success' }
+    let(:prefs_file) do
+      instance_double(
+        'HashMap',
+        name: '.awskeyring',
+        write: ''
+      )
+    end
+    let(:test_keychain) do
+      instance_double(
+        'HashMap',
+        lock_interval: 0,
+        lock_on_sleep: false
+      )
+    end
+
     before do
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?)
         .with(/\.awskeyring/)
         .and_return(false)
+      allow(File).to receive(:new).and_call_original
+      allow(File).to receive(:new)
+        .and_return(prefs_file)
+      allow(prefs_file).to receive(:write)
+        .and_return(write_success)
+      allow(Keychain).to receive(:create)
+        .and_return(test_keychain)
+      allow(test_keychain).to receive(:lock_interval=)
+      allow(test_keychain).to receive(:lock_on_sleep=)
     end
 
     it 'has a version number' do
@@ -23,6 +48,10 @@ describe Awskeyring do
 
     it 'can not load preferences' do
       expect(awskeyring.prefs).to eq({})
+    end
+
+    it 'creates a new file' do
+      expect(awskeyring.init_keychain(awskeyring: 'awskeyringtest')).to eq(write_success)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.start do
+  minimum_coverage 85
+  add_filter '/spec/'
+end
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'awskeyring'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'simplecov'
 SimpleCov.start do
-  minimum_coverage 85
+  minimum_coverage 90
   add_filter '/spec/'
 end
 


### PR DESCRIPTION
# Description

This adds a coverage report using SimpleCov and set s a minimum test coverage of 90%, the builds will fail if the test coverage dips below this mark.

Fixes: Coverage

## Did you run the Tests?

- [X] Rubocop
- [X] Rspec
- [X] Filemode
- [X] Yard
- Coverage 90.78%
