### PR TITLE
Warn about missing accounts/roles

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -75,6 +75,8 @@ en:
     delexpired: '# Removing expired session credentials'
     exec: '# COMMAND not provided'
     missing: '# Config missing, run `%{bin} initialise` to recreate.'
+    missing_account: '# No accounts added, run `%{bin} add` to add.'
+    missing_role: '# No roles added, run `%{bin} add-role` to add.'
     rotate: '# You have two access keys for account %{account}'
     temporary: '# Using temporary session credentials.'
     timeout: '# It is STRONGLY recommended to set your keychain to lock in 5 minutes or less.'

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -72,6 +72,10 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   desc 'list', I18n.t('list.desc')
   # list the accounts
   def list
+    if Awskeyring.list_account_names.empty?
+      warn I18n.t('message.missing_account', bin: File.basename($PROGRAM_NAME))
+      exit 1
+    end
     puts Awskeyring.list_account_names.join("\n")
   end
 
@@ -80,6 +84,10 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   method_option 'detail', type: :boolean, aliases: '-d', desc: I18n.t('method_option.detail'), default: false
   # List roles
   def list_role
+    if Awskeyring.list_role_names.empty?
+      warn I18n.t('message.missing_role', bin: File.basename($PROGRAM_NAME))
+      exit 1
+    end
     if options['detail']
       puts Awskeyring.list_role_names_plus.join("\n")
     else

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -59,6 +59,24 @@ describe AwskeyringCommand do
     end
   end
 
+  context 'when no accounts or roles are set' do
+    before do
+      allow(Awskeyring).to receive(:list_account_names).and_return([])
+      allow(Awskeyring).to receive(:list_role_names).and_return([])
+      allow(Awskeyring).to receive(:prefs).and_return('{"awskeyring": "awskeyringtest"}')
+    end
+
+    it 'tells you that you must add accounts' do
+      expect { described_class.start(%w[list]) }.to raise_error
+        .and output(/No accounts added, run `\w+ add` to add./).to_stderr
+    end
+
+    it 'tells you that you must add roles' do
+      expect { described_class.start(%w[list-role]) }.to raise_error
+        .and output(/No roles added, run `\w+ add-role` to add./).to_stderr
+    end
+  end
+
   context 'when accounts and roles are set' do
     before do
       allow(Awskeyring).to receive(:list_account_names).and_return(%w[company personal servian])


### PR DESCRIPTION
# Description

When a new user tries to list accounts/roles it would just print nothing. Now you get a warning message to Add them.

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
