### PR TITLE
Console specify browser

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -49,6 +49,7 @@ en:
     notoken: 'Do not use saved token.'
     noremote: 'Do not validate with remote api.'
     path: 'The service PATH to open.'
+    browser: 'Specify an alternative browser.'
     role: 'The ROLE to assume.'
     secret: 'AWS account secret.'
     unset: 'Unset environment variables.'

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -387,11 +387,11 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
 
   desc 'console ACCOUNT', I18n.t('console.desc')
   method_option :path, type: :string, aliases: '-p', desc: I18n.t('method_option.path')
-  method_option 'browser', type: :boolean, aliases: '-b', desc: I18n.t('method_option.browser'), default: false
+  method_option :browser, type: :string, aliases: '-b', desc: I18n.t('method_option.browser')
   method_option 'no-token', type: :boolean, aliases: '-n', desc: I18n.t('method_option.notoken'), default: false
   method_option 'no-open', type: :boolean, aliases: '-o', desc: I18n.t('method_option.noopen'), default: false
   # Open the AWS Console
-  def console(account = nil, browser = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def console(account = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     account = ask_check(
       existing: account,
       message: I18n.t('message.account'),
@@ -418,7 +418,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     if options['no-open']
       puts login_url
     else
-      spawn_cmd = browser.nil? ? "open \"#{login_url}\"" : "open -a \"#{browser}\" \"#{login_url}\""
+      spawn_cmd = options[:browser] ? "open -a \"#{options[:browser]}\" \"#{login_url}\"" : "open \"#{login_url}\""
       pid = Process.spawn(spawn_cmd)
       Process.wait pid
     end

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -387,10 +387,11 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
 
   desc 'console ACCOUNT', I18n.t('console.desc')
   method_option :path, type: :string, aliases: '-p', desc: I18n.t('method_option.path')
+  method_option 'browser', type: :boolean, aliases: '-b', desc: I18n.t('method_option.browser'), default: false
   method_option 'no-token', type: :boolean, aliases: '-n', desc: I18n.t('method_option.notoken'), default: false
   method_option 'no-open', type: :boolean, aliases: '-o', desc: I18n.t('method_option.noopen'), default: false
   # Open the AWS Console
-  def console(account = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def console(account = nil, browser = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     account = ask_check(
       existing: account,
       message: I18n.t('message.account'),
@@ -417,7 +418,11 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     if options['no-open']
       puts login_url
     else
-      pid = Process.spawn("open \"#{login_url}\"")
+      if browser != nil
+        pid = Process.spawn("open -a \"#{browser}\" \"#{login_url}\"")
+      else
+        pid = Process.spawn("open \"#{login_url}\"")
+      end
       Process.wait pid
     end
   end

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -418,11 +418,8 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     if options['no-open']
       puts login_url
     else
-      if browser != nil
-        pid = Process.spawn("open -a \"#{browser}\" \"#{login_url}\"")
-      else
-        pid = Process.spawn("open \"#{login_url}\"")
-      end
+      spawn_cmd = browser.nil? ? "open \"#{login_url}\"" : "open -a \"#{browser}\" \"#{login_url}\""
+      pid = Process.spawn(spawn_cmd)
       Process.wait pid
     end
   end

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "June 2020" "" ""
+.TH "AWSKEYRING" "5" "November 2020" "" ""
 .
 .SH "NAME"
 \fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain
@@ -37,10 +37,10 @@ add\-role ROLE:
 Adds a ROLE to the keyring
 .
 .TP
-console ACCOUNT:
+console ACCOUNT [\-\-browser BROWSER]:
 .
 .IP
-Open the AWS Console for the ACCOUNT
+Open the AWS Console for the ACCOUNT in BROWSER or the default browser if BROWSER not specified
 .
 .TP
 env ACCOUNT:

--- a/man/awskeyring.5.ronn
+++ b/man/awskeyring.5.ronn
@@ -26,9 +26,9 @@ The commands are as follows:
 
     Adds a ROLE to the keyring
 
-* console ACCOUNT:
+* console ACCOUNT [--browser BROWSER]:
 
-    Open the AWS Console for the ACCOUNT
+    Open the AWS Console for the ACCOUNT in BROWSER or the default browser if BROWSER not specified
 
 * env ACCOUNT:
 


### PR DESCRIPTION
# Description

Add --browser option to console command

Added ability to pass the console command a --browser [-b] option to specify the name of an alternative browser.
Basically adds the -a flag to the open command, with the browser string appended
eg. `awskeyring console <profile> --browser "google chrome"`

Fixes #71

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard

@tristanmorgan
