### PR TITLE
Include expiry time export, AWS_CREDENTIAL_EXPIRATION

### DIFF
--- a/lib/awskeyring/awsapi.rb
+++ b/lib/awskeyring/awsapi.rb
@@ -27,6 +27,7 @@ module Awskeyring
       AWS_ACCOUNT_NAME
       AWS_ACCESS_KEY_ID
       AWS_ACCESS_KEY
+      AWS_CREDENTIAL_EXPIRATION
       AWS_SECRET_ACCESS_KEY
       AWS_SECRET_KEY
       AWS_SECURITY_TOKEN
@@ -125,6 +126,8 @@ module Awskeyring
     def self.get_env_array(params = {})
       env_var = {}
       env_var['AWS_DEFAULT_REGION'] = 'us-east-1' unless region
+
+      params[:expiration] = Time.at(params[:expiry]).iso8601 unless params[:expiry].nil?
 
       params.each_key do |param_name|
         AWS_ENV_VARS.each do |var_name|

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -88,7 +88,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
       warn I18n.t('message.missing_role', bin: File.basename($PROGRAM_NAME))
       exit 1
     end
-    if options['detail']
+    if options[:detail]
       puts Awskeyring.list_role_names_plus.join("\n")
     else
       puts Awskeyring.list_role_names.join("\n")
@@ -100,7 +100,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   method_option 'unset', type: :boolean, aliases: '-u', desc: I18n.t('method_option.unset'), default: false
   # Print Env vars
   def env(account = nil)
-    if options['unset']
+    if options[:unset]
       put_env_string(account: nil, key: nil, secret: nil, token: nil)
     else
       account = ask_check(

--- a/spec/lib/awskeyring/awsapi_spec.rb
+++ b/spec/lib/awskeyring/awsapi_spec.rb
@@ -356,6 +356,7 @@ describe Awskeyring::Awsapi do
     it 'returns an array of env vars for the Credential' do
       expect(awsapi.get_env_array(
                account: 'test',
+               expiry: 1_489_305_329,
                key: 'ASIAIOSFODNN7EXAMPLE',
                secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',
                token: role_token
@@ -363,6 +364,7 @@ describe Awskeyring::Awsapi do
                'AWS_ACCESS_KEY' => 'ASIAIOSFODNN7EXAMPLE',
                'AWS_ACCESS_KEY_ID' => 'ASIAIOSFODNN7EXAMPLE',
                'AWS_ACCOUNT_NAME' => 'test',
+               'AWS_CREDENTIAL_EXPIRATION' => Time.at(1_489_305_329).iso8601,
                'AWS_DEFAULT_REGION' => 'us-east-1',
                'AWS_SECRET_ACCESS_KEY' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',
                'AWS_SECRET_KEY' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -207,6 +207,7 @@ export AWS_ACCESS_KEY_ID="AKIATESTTEST"
 export AWS_ACCESS_KEY="AKIATESTTEST"
 export AWS_SECRET_ACCESS_KEY="biglongbase64"
 export AWS_SECRET_KEY="biglongbase64"
+unset AWS_CREDENTIAL_EXPIRATION
 unset AWS_SECURITY_TOKEN
 unset AWS_SESSION_TOKEN
 )).to_stdout
@@ -219,6 +220,7 @@ unset AWS_SESSION_TOKEN
 unset AWS_ACCOUNT_NAME
 unset AWS_ACCESS_KEY_ID
 unset AWS_ACCESS_KEY
+unset AWS_CREDENTIAL_EXPIRATION
 unset AWS_SECRET_ACCESS_KEY
 unset AWS_SECRET_KEY
 unset AWS_SECURITY_TOKEN
@@ -234,6 +236,7 @@ unset AWS_SESSION_TOKEN
         'AWS_ACCOUNT_NAME' => 'test',
         'AWS_ACCESS_KEY_ID' => 'ASIATESTTEST',
         'AWS_ACCESS_KEY' => 'ASIATESTTEST',
+        'AWS_CREDENTIAL_EXPIRATION' => Time.at(1_310_414_129).iso8601,
         'AWS_SECRET_ACCESS_KEY' => 'bigerlongbase64',
         'AWS_SECRET_KEY' => 'bigerlongbase64',
         'AWS_SECURITY_TOKEN' => 'evenlongerbase64token',
@@ -289,6 +292,7 @@ export AWS_SECRET_ACCESS_KEY="bigerlongbase64"
 export AWS_SECRET_KEY="bigerlongbase64"
 export AWS_SECURITY_TOKEN="evenlongerbase64token"
 export AWS_SESSION_TOKEN="evenlongerbase64token"
+export AWS_CREDENTIAL_EXPIRATION="#{Time.at(1_310_414_129).iso8601}"
 )).to_stdout
       expect(Awskeyring).to have_received(:get_valid_creds).with(account: 'test', no_token: false)
     end
@@ -301,6 +305,7 @@ export AWS_ACCESS_KEY_ID="AKIATESTTEST"
 export AWS_ACCESS_KEY="AKIATESTTEST"
 export AWS_SECRET_ACCESS_KEY="biglongbase64"
 export AWS_SECRET_KEY="biglongbase64"
+unset AWS_CREDENTIAL_EXPIRATION
 unset AWS_SECURITY_TOKEN
 unset AWS_SESSION_TOKEN
 )).to_stdout


### PR DESCRIPTION
# Description

This adds support for the AWS_CREDENTIAL_EXPIRATION environment variable. Its supported in Botocore but doesn't seem to be in the other SDK's yet.

Related [botocore/pull/1187](https://github.com/boto/botocore/pull/1187)

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
