### PR TITLE
Default nil token (fix #75)

### DIFF
--- a/lib/awskeyring/awsapi.rb
+++ b/lib/awskeyring/awsapi.rb
@@ -145,7 +145,7 @@ module Awskeyring
     # @param [String] key The aws_access_key_id
     # @param [String] secret The aws_secret_access_key
     # @param [String] token The aws_session_token
-    def self.verify_cred(key:, secret:, token:)
+    def self.verify_cred(key:, secret:, token: nil)
       begin
         ENV['AWS_DEFAULT_REGION'] = 'us-east-1' unless region
         sts = Aws::STS::Client.new(access_key_id: key, secret_access_key: secret, session_token: token)

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -209,7 +209,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
       existing: options[:mfa], message: I18n.t('message.mfa'),
       flags: 'optional', validator: Awskeyring::Validate.method(:mfa_arn)
     )
-    Awskeyring::Awsapi.verify_cred(key: key, secret: secret, token: nil) unless options['no-remote']
+    Awskeyring::Awsapi.verify_cred(key: key, secret: secret) unless options['no-remote']
     Awskeyring.add_account(
       account: account,
       key: key,

--- a/spec/lib/awskeyring/awsapi_spec.rb
+++ b/spec/lib/awskeyring/awsapi_spec.rb
@@ -226,6 +226,7 @@ describe Awskeyring::Awsapi do
   context 'when credentials are verified' do
     let(:key) { 'AKIA1234567890ABCDEF' }
     let(:secret) { 'AbCkTEsTAAAi8ni0987ASDFwer23j14FEQW3IUJV' }
+    let(:token) { 'AQoDYXdzEPT//////////wEXAMPLEtc764assume_roleDOk4x4HIZ8j4FZTwdQWLWsKWHGBuFqwAeMi' }
 
     let(:sts_client) { instance_double(Aws::STS::Client) }
 
@@ -240,7 +241,11 @@ describe Awskeyring::Awsapi do
     end
 
     it 'calls get_caller_identity' do
-      expect(awsapi.verify_cred(key: key, secret: secret, token: nil)).to be(true)
+      expect(awsapi.verify_cred(key: key, secret: secret)).to be(true)
+    end
+
+    it 'calls get_caller_identity with a token' do
+      expect(awsapi.verify_cred(key: key, secret: secret, token: token)).to be(true)
     end
   end
 

--- a/spec/lib/awskeyring_command_more_spec.rb
+++ b/spec/lib/awskeyring_command_more_spec.rb
@@ -286,6 +286,7 @@ describe AwskeyringCommand do
         described_class.start(['add', 'test', '-k', access_key, '-s', secret_access_key])
       end.to output("# Added account test\n").to_stdout
       expect(Awskeyring::Awsapi).to have_received(:verify_cred)
+        .with(key: access_key, secret: secret_access_key)
       expect(Awskeyring).not_to have_received(:update_account)
       expect(Awskeyring).to have_received(:add_account)
     end
@@ -295,6 +296,7 @@ describe AwskeyringCommand do
         described_class.start(['update', 'tested', '-k', access_key, '-s', secret_access_key])
       end.to output("# Updated account tested\n").to_stdout
       expect(Awskeyring::Awsapi).to have_received(:verify_cred)
+        .with(key: access_key, secret: secret_access_key)
       expect(Awskeyring).to have_received(:update_account)
       expect(Awskeyring).not_to have_received(:add_account)
     end


### PR DESCRIPTION
# Description

Sets a default value of nil for the token param to verify_cred. adds a little more test coverage.

Fixes #75

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
