### PR TITLE
(Auto)Complete rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ There are also short forms of most commands if you prefer:
 
 To set your environment easily the following bash function helps:
 
-    awsenv() { eval "$(awskeyring env $@)"; }
+    awsenv() { eval "$(awskeyring env ${@:-$AWS_ACCOUNT_NAME})"; }
 
 ## Development
 

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -33,7 +33,6 @@ en:
     noremote: 'Do not validate with remote api.'
     path: 'The service PATH to open.'
     browser: 'Specify an alternative browser.'
-    role: 'The ROLE to assume.'
     secret: 'AWS account secret.'
     unset: 'Unset environment variables.'
   message:

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -17,17 +17,13 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
 
   map %w[--version -v] => :__version
   map %w[--help -h] => :help
-  map 'init' => :initialise
   map 'adr' => :add_role
-  map 'con' => :console
+  map 'assume-role' => :token
   map 'ls' => :list
   map 'lsr' => :list_role
   map 'rm' => :remove
   map 'rmr' => :remove_role
   map 'rmt' => :remove_token
-  map 'rot' => :rotate
-  map 'tok' => :token
-  map 'up' => :update
   default_command :default
 
   # default to returning an error on failure.
@@ -91,9 +87,8 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     puts Awskeyring.list_account_names.join("\n")
   end
 
-  map 'list-role' => :list_role
   desc 'list-role', I18n.t('list_role_desc')
-  method_option 'detail', type: :boolean, aliases: '-d', desc: I18n.t('method_option.detail'), default: false
+  method_option :detail, type: :boolean, aliases: '-d', desc: I18n.t('method_option.detail'), default: false
   # List roles
   def list_role
     if Awskeyring.list_role_names.empty?
@@ -109,7 +104,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
 
   desc 'env ACCOUNT', I18n.t('env_desc')
   method_option 'no-token', type: :boolean, aliases: '-n', desc: I18n.t('method_option.notoken'), default: false
-  method_option 'unset', type: :boolean, aliases: '-u', desc: I18n.t('method_option.unset'), default: false
+  method_option :unset, type: :boolean, aliases: '-u', desc: I18n.t('method_option.unset'), default: false
   # Print Env vars
   def env(account = nil)
     if options[:unset]
@@ -258,7 +253,6 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     puts I18n.t('message.upaccount', account: account)
   end
 
-  map 'add-role' => :add_role
   desc 'add-role ROLE', I18n.t('add_role_desc')
   method_option :arn, type: :string, aliases: '-a', desc: I18n.t('method_option.arn')
   # Add a role
@@ -299,7 +293,6 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     Awskeyring.delete_token(account: account, message: I18n.t('message.deltoken', account: account))
   end
 
-  map 'remove-role' => :remove_role
   desc 'remove-role ROLE', I18n.t('remove_role_desc')
   # remove a role
   def remove_role(role = nil)
@@ -343,7 +336,6 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   end
 
   desc 'token ACCOUNT [ROLE] [MFA]', I18n.t('token_desc')
-  method_option :role, type: :string, aliases: '-r', desc: I18n.t('method_option.role')
   method_option :code, type: :string, aliases: '-c', desc: I18n.t('method_option.code')
   method_option :duration, type: :string, aliases: '-d', desc: I18n.t('method_option.duration')
   # generate a sessiopn token
@@ -354,7 +346,6 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
       validator: Awskeyring.method(:account_exists),
       limited_to: Awskeyring.list_account_names
     )
-    role ||= options[:role]
     if role
       role = ask_check(
         existing: role, message: I18n.t('message.role'), validator: Awskeyring.method(:role_exists),
@@ -472,7 +463,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     case prev
     when 'help', File.basename($PROGRAM_NAME)
       comp_len = 0
-    when 'remove-role', '-r', 'rmr'
+    when 'remove-role', 'rmr'
       comp_len = 2
     when '--path', '-p'
       comp_len = 40

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -285,12 +285,12 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
 
   desc 'remove-token ACCOUNT', I18n.t('remove_token_desc')
   # remove a session token
-  def remove_token(account = nil)
-    account = ask_check(
-      existing: account, message: I18n.t('message.account'), validator: Awskeyring.method(:token_exists),
+  def remove_token(token = nil)
+    token = ask_check(
+      existing: token, message: I18n.t('message.account'), validator: Awskeyring.method(:token_exists),
       limited_to: Awskeyring.list_token_names
     )
-    Awskeyring.delete_token(account: account, message: I18n.t('message.deltoken', account: account))
+    Awskeyring.delete_token(account: token, message: I18n.t('message.deltoken', account: token))
   end
 
   desc 'remove-role ROLE', I18n.t('remove_role_desc')
@@ -432,14 +432,18 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   # autocomplete
   def autocomplete(curr, prev)
     comp_line = ENV['COMP_LINE']
-    unless comp_line
+    comp_point_str = ENV['COMP_POINT']
+    unless comp_line && comp_point_str
       exec_name = File.basename($PROGRAM_NAME)
       warn I18n.t('message.awskeyring', path: $PROGRAM_NAME, bin: exec_name)
       exit 1
     end
 
-    curr, comp_len, sub_cmd = comp_type(comp_line: comp_line, curr: curr, prev: prev)
-    print_auto_resp(curr, comp_len, sub_cmd)
+    comp_lines = comp_line[0..(comp_point_str.to_i)].split
+
+    comp_type, sub_cmd = comp_type(comp_lines: comp_lines, prev: prev)
+    list = fetch_auto_resp(comp_type, sub_cmd)
+    puts list.select { |elem| elem.start_with?(curr) }.sort!.join("\n")
   end
 
   private
@@ -454,59 +458,63 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     cred
   end
 
-  def comp_type(comp_line:, curr:, prev:)
-    comp_len = comp_line.split.index(prev)
-    sub_cmd = sub_command(comp_line.split)
-
-    comp_len = 3 if curr.start_with?('-')
+  def comp_type(comp_lines:, prev:)
+    sub_cmd = sub_command(comp_lines)
+    comp_idx = comp_lines.rindex(prev)
 
     case prev
-    when 'help', File.basename($PROGRAM_NAME)
-      comp_len = 0
-    when 'remove-role', 'rmr'
-      comp_len = 2
     when '--path', '-p'
-      comp_len = 40
-    when 'remove-token', 'rmt'
-      comp_len = 50
+      comp_type = :path_type
     when '--browser', '-b'
-      comp_len = 60
+      comp_type = :browser_type
+    else
+      comp_type = :command
+      comp_type = param_type(comp_idx, sub_cmd) unless sub_cmd.empty?
     end
 
-    [curr, comp_len, sub_cmd]
+    [comp_type, sub_cmd]
+  end
+
+  def param_type(comp_idx, sub_cmd)
+    param_list = method(sub_cmd).parameters
+    if comp_idx.zero?
+      :command
+    elsif comp_idx > param_list.length
+      :flag
+    else
+      param_list[comp_idx - 1][1]
+    end
   end
 
   def sub_command(comp_lines)
-    return nil if comp_lines.nil? || comp_lines.length < 2
+    return '' if comp_lines.nil? || comp_lines.length < 2
 
-    sub_cmd = comp_lines[1]
+    sub_cmd = comp_lines[1].tr('-', '_')
 
-    return sub_cmd if self.class.all_commands.keys.index(sub_cmd)
+    sub_cmds = self.class.all_commands.keys.select { |elem| elem.start_with?(sub_cmd) }
+
+    return sub_cmds.first if sub_cmds.length == 1
 
     self.class.map[sub_cmd].to_s
   end
 
-  def print_auto_resp(curr, len, sub_cmd) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
-    list = []
-    case len
-    when 0
-      list = list_commands
-    when 1
-      list = Awskeyring.list_account_names
-    when 2
-      list = Awskeyring.list_role_names
-    when 3..10
-      list = list_arguments(command: sub_cmd)
-    when 40
-      list = Awskeyring.list_console_path
-    when 50
-      list = Awskeyring.list_token_names
-    when 60
-      list = Awskeyring.list_browsers
+  def fetch_auto_resp(comp_type, sub_cmd)
+    case comp_type
+    when :command
+      list_commands
+    when :account
+      Awskeyring.list_account_names
+    when :role
+      Awskeyring.list_role_names
+    when :path_type
+      Awskeyring.list_console_path
+    when :token
+      Awskeyring.list_token_names
+    when :browser_type
+      Awskeyring.list_browsers
     else
-      exit 1
+      list_arguments(command: sub_cmd)
     end
-    puts list.select { |elem| elem.start_with?(curr) }.sort!.join("\n")
   end
 
   def list_commands
@@ -515,9 +523,11 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   end
 
   def list_arguments(command:)
-    exit 1 if command.empty?
-    self.class.all_commands[command].options.values.map(&:aliases).flatten! +
-      self.class.all_commands[command].options.values.map(&:switch_name)
+    options = self.class.all_commands[command].options.values
+    exit 1 if options.empty?
+
+    options.map(&:aliases).flatten! +
+      options.map(&:switch_name)
   end
 
   def put_env_string(cred)

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "April 2021" "" ""
+.TH "AWSKEYRING" "5" "May 2021" "" ""
 .
 .SH "NAME"
 \fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain
@@ -197,9 +197,6 @@ Create an STS Token from a ROLE or an MFA code
 .br
 .
 .IP
-\-r, \-\-role=ROLE: The ROLE to assume\.
-.
-.br
 \-c, \-\-code=CODE: Virtual mfa CODE\.
 .
 .br

--- a/man/awskeyring.5.ronn
+++ b/man/awskeyring.5.ronn
@@ -110,7 +110,6 @@ The commands are as follows:
 
     Create an STS Token from a ROLE or an MFA code<br>
 
-    -r, --role=ROLE: The ROLE to assume.<br>
     -c, --code=CODE: Virtual mfa CODE.<br>
     -d, --duration=DURATION: Session DURATION in seconds.
 

--- a/spec/lib/awskeyring_command_more_spec.rb
+++ b/spec/lib/awskeyring_command_more_spec.rb
@@ -143,7 +143,7 @@ describe AwskeyringCommand do
 
     it 'tries to receive a new token' do
       expect do
-        described_class.start(%w[token test -r role])
+        described_class.start(%w[token test role])
       end.to output(
         "# Token saved for account test\n# Authentication valid until #{Time.at(1_422_992_424)}\n"
       ).to_stdout
@@ -199,7 +199,7 @@ describe AwskeyringCommand do
 
     it 'tries to receive a new token with an MFA and role' do
       expect do
-        described_class.start(%w[token test -r role -c 987654])
+        described_class.start(%w[token test role -c 987654])
       end.to output(
         "# Token saved for account test\n# Authentication valid until #{Time.at(1_422_992_424)}\n"
       ).to_stdout

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -88,7 +88,7 @@ describe AwskeyringCommand do
   context 'when accounts and roles are set' do
     before do
       allow(Awskeyring).to receive(:list_account_names).and_return(%w[company personal servian])
-      allow(Awskeyring).to receive(:list_token_names).and_return(%w[personal servian])
+      allow(Awskeyring).to receive(:list_token_names).and_return(%w[personal sersaml])
       allow(Awskeyring).to receive(:list_role_names).and_return(%w[admin minion readonly])
       allow(Awskeyring).to receive(:list_role_names_plus)
         .and_return(%W[admin\tarn1 minion\tarn2 readonly\tarn3])
@@ -114,6 +114,7 @@ describe AwskeyringCommand do
 
     it 'lists accounts with autocomplete' do
       ENV['COMP_LINE'] = 'awskeyring token ser'
+      ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
       expect { described_class.start(%w[autocomplete ser token]) }
         .to output("servian\n").to_stdout
       ENV['COMP_LINE'] = nil
@@ -121,50 +122,65 @@ describe AwskeyringCommand do
 
     it 'lists roles with autocomplete' do
       ENV['COMP_LINE'] = 'awskeyring remove-role min'
+      ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
       expect { described_class.start(%w[autocomplete min remove-role]) }
         .to output("minion\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
 
-    it 'lists commands with autocomplete' do
+    it 'lists all commands with autocomplete' do
       ENV['COMP_LINE'] = 'awskeyring '
+      ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
       expect { described_class.start(['autocomplete', '', 'awskeyring']) }
         .to output(/--version\nadd\nadd-role\nconsole\nenv\nexec\nhelp/).to_stdout
       ENV['COMP_LINE'] = nil
     end
 
-    it 'lists commands with autocomplete for help' do
-      ENV['COMP_LINE'] = 'awskeyring help con'
-      expect { described_class.start(%w[autocomplete con help]) }
+    it 'lists commands with autocomplete' do
+      ENV['COMP_LINE'] = 'awskeyring con'
+      ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
+      expect { described_class.start(%w[autocomplete con awskeyring]) }
         .to output("console\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
 
+    it 'lists commands with autocomplete for help' do
+      ENV['COMP_LINE'] = 'awskeyring help list'
+      ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
+      expect { described_class.start(%w[autocomplete list help]) }
+        .to output("list\nlist-role\n").to_stdout
+      ENV['COMP_LINE'] = nil
+    end
+
     it 'lists flags with autocomplete' do
-      ENV['COMP_LINE'] = 'awskeyring token servian minion --dura'
-      expect { described_class.start(%w[autocomplete --dura minion]) }
+      ENV['COMP_LINE'] = 'awskeyring token servian minion 123456 --dura'
+      ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
+      expect { described_class.start(%w[autocomplete --dura 123456]) }
         .to output("--duration\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
 
     it 'lists console paths with autocomplete' do
       ENV['COMP_LINE'] = 'awskeyring console servian --path cloud'
+      ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
       expect { described_class.start(%w[autocomplete cloud --path]) }
         .to output("cloudformation\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
 
     it 'lists common browsers with autocomplete' do
-      ENV['COMP_LINE'] = 'awskeyring console servian --browser Sa'
+      ENV['COMP_LINE'] = 'awskeyring con servian --browser Sa'
+      ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
       expect { described_class.start(%w[autocomplete Sa --browser]) }
         .to output("Safari\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
 
     it 'lists token names with autocomplete' do
-      ENV['COMP_LINE'] = 'awskeyring remove-token ser'
-      expect { described_class.start(%w[autocomplete ser remove-token]) }
-        .to output("servian\n").to_stdout
+      ENV['COMP_LINE'] = 'awskeyring rmt ser'
+      ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
+      expect { described_class.start(%w[autocomplete ser rmt]) }
+        .to output("sersaml\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
 

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -160,6 +160,14 @@ describe AwskeyringCommand do
       ENV['COMP_LINE'] = nil
     end
 
+    it 'lists flags with autocomplete for partial commands' do
+      ENV['COMP_LINE'] = 'awskeyring con servian --p'
+      ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s
+      expect { described_class.start(%w[autocomplete --p servian]) }
+        .to output("--path\n").to_stdout
+      ENV['COMP_LINE'] = nil
+    end
+
     it 'lists console paths with autocomplete' do
       ENV['COMP_LINE'] = 'awskeyring console servian --path cloud'
       ENV['COMP_POINT'] = ENV['COMP_LINE'].size.to_s


### PR DESCRIPTION
# Description

First I'm removing some redundant aliases and the "--role" parameter in preparation for using symbols in autocomplete. This makes the code clearer (no magic numbers like 40 equals console paths) and cover some more edge cases.

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
