### PR TITLE
Complete flags for -v command

### DIFF
--- a/lib/awskeyring/awsapi.rb
+++ b/lib/awskeyring/awsapi.rb
@@ -209,7 +209,7 @@ module Awskeyring
     # Get the signin token param
     private_class_method def self.token_param(session_json:)
       get_signin_token_url = AWS_SIGNIN_URL + '?Action=getSigninToken' \
-                             '&Session=' + CGI.escape(session_json)
+                                              '&Session=' + CGI.escape(session_json)
 
       uri       = URI(get_signin_token_url)
       request   = Net::HTTP.new(uri.host, uri.port)

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -499,7 +499,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
 
     return sub_cmds.first if sub_cmds.length == 1
 
-    self.class.map[sub_cmd].to_s
+    self.class.map[comp_lines[1]].to_s
   end
 
   # given a type return the right list for completions

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "June 2021" "" ""
+.TH "AWSKEYRING" "5" "July 2021" "" ""
 .
 .SH "NAME"
 \fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain

--- a/spec/lib/awskeyring_command_more_spec.rb
+++ b/spec/lib/awskeyring_command_more_spec.rb
@@ -137,7 +137,7 @@ describe AwskeyringCommand do
       expect do
         described_class.start(['import', 'testaccount', '-r'])
       end.to output("# Token saved for account testaccount\n"\
-        "# Authentication valid until #{Time.at(1_489_305_329)}\n").to_stdout
+                    "# Authentication valid until #{Time.at(1_489_305_329)}\n").to_stdout
       expect(Awskeyring::Awsapi).not_to have_received(:verify_cred)
     end
 

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -32,7 +32,7 @@ describe AwskeyringCommand do
     end
 
     it 'returns the version number with checks online' do
-      expect { described_class.start(%w[__version]) }
+      expect { described_class.start(%w[--version]) }
         .to output(/latest version v1\.1\.1/).to_stdout
     end
 
@@ -109,6 +109,7 @@ describe AwskeyringCommand do
       ['awskeyring token servian minion 123456 --dura', %w[--dura 123456], "--duration\n", 'flags'],
       ['awskeyring token servian minion --dura', %w[--dura minion], "--duration\n", 'flags'],
       ['awskeyring con servian --p', %w[--p servian], "--path\n", 'flags'],
+      ['awskeyring -v --n', %w[--n -v], "--no-remote\n", 'flags for --version'],
       ['awskeyring exec servian --no', %w[--no servian], "--no-bundle\n--no-token\n", 'flags for exec'],
       ['awskeyring console servian --path cloud', %w[cloud --path], "cloudformation\n", 'console paths'],
       ['awskeyring con servian --browser Sa',  %w[Sa --browser], "Safari\n", 'browsers']


### PR DESCRIPTION
# Description

Fixes the ability for autocomplete to work for for aliased commands that have hyphens '-'.

Includes a few formatting changes.

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
