### PR TITLE
Partial name match for validation.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'ronn'
 require 'github_changelog_generator/task'
@@ -49,8 +48,9 @@ end
 desc 'generate manpage'
 task :ronn do
   puts 'Running Ronn...'
-  roff_text = Ronn::Document.new('man/awskeyring.5.ronn').to_roff
-  File.write('man/awskeyring.5', roff_text)
+  doc = Ronn::Document.new('man/awskeyring.5.ronn')
+  doc.date = Time.parse(`git show -s --format=%ad --date=short`)
+  File.write('man/awskeyring.5', doc.to_roff)
   puts "done\n\n"
 end
 

--- a/lib/awskeyring.rb
+++ b/lib/awskeyring.rb
@@ -97,6 +97,17 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
     all_items.where(account: account).first
   end
 
+  # return item that matches a prefix if only one.
+  def self.solo_select(list, prefix)
+    return prefix if list.include?(prefix)
+
+    list.select! { |elem| elem.start_with?(prefix) }
+
+    return list.first if list.length == 1
+
+    nil
+  end
+
   # Add an account item
   #
   # @param [String] account The account name to create
@@ -317,7 +328,7 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
   # @param [String] account_name the associated account name.
   def self.account_exists(account_name)
     Awskeyring::Validate.account_name(account_name)
-    raise 'Account does not exist' unless list_account_names.include?(account_name)
+    raise 'Account does not exist' unless (account_name = solo_select(list_account_names, account_name))
 
     account_name
   end
@@ -347,7 +358,7 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
   # @param [String] role_name the associated role name.
   def self.role_exists(role_name)
     Awskeyring::Validate.role_name(role_name)
-    raise 'Role does not exist' unless list_role_names.include?(role_name)
+    raise 'Role does not exist' unless (role_name = solo_select(list_role_names, role_name))
 
     role_name
   end
@@ -367,7 +378,7 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
   # @param [String] token_name the associated account name.
   def self.token_exists(token_name)
     Awskeyring::Validate.account_name(token_name)
-    raise 'Token does not exist' unless list_token_names.include?(token_name)
+    raise 'Token does not exist' unless (token_name = solo_select(list_token_names, token_name))
 
     token_name
   end

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -16,7 +16,6 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   I18n.backend.load_translations
 
   map %w[--version -v] => :__version
-  map %w[--help -h] => :help
   map 'adr' => :add_role
   map 'assume-role' => :token
   map 'ls' => :list
@@ -491,15 +490,13 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
 
   # catch the command from prefixes and aliases
   def sub_command(comp_lines)
-    return '' if comp_lines.nil? || comp_lines.length < 2
+    return '' if comp_lines.length < 2
 
-    sub_cmd = comp_lines[1].tr('-', '_')
+    sub_cmd = comp_lines[1]
 
-    sub_cmds = self.class.all_commands.keys.select { |elem| elem.start_with?(sub_cmd) }
+    return self.class.map[sub_cmd].to_s if self.class.map.key? sub_cmd
 
-    return sub_cmds.first if sub_cmds.length == 1
-
-    self.class.map[comp_lines[1]].to_s
+    (Awskeyring.solo_select(list_commands, sub_cmd) || '').tr('-', '_')
   end
 
   # given a type return the right list for completions

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -109,6 +109,7 @@ describe AwskeyringCommand do
       ['awskeyring token servian minion 123456 --dura', %w[--dura 123456], "--duration\n", 'flags'],
       ['awskeyring token servian minion --dura', %w[--dura minion], "--duration\n", 'flags'],
       ['awskeyring con servian --p', %w[--p servian], "--path\n", 'flags'],
+      ['awskeyring add sarveun --n', %w[--n sarveun], "--no-remote\n", 'flags for add'],
       ['awskeyring -v --n', %w[--n -v], "--no-remote\n", 'flags for --version'],
       ['awskeyring exec servian --no', %w[--no servian], "--no-bundle\n--no-token\n", 'flags for exec'],
       ['awskeyring console servian --path cloud', %w[cloud --path], "cloudformation\n", 'console paths'],


### PR DESCRIPTION
# Description

This allows  accounts, roles and token names to be matched with just a prefix but also allow when one name is a prefix of another (eg. "test" and "test2") this works for the validation checks for existing names and fixes a bug with autocomplete matching prefixes. (specifically "add" and "add-role").

Also added small tweak to date stamp for man page generation.

## Did you run the Tests?

- [X] Rubocop
- [X] Rspec
- [X] Filemode
- [X] Yard
