### PR TITLE
Add account validadtion to exec command.

### DIFF
--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -124,7 +124,8 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   # Print JSON for use with credential_process
   def json(account)
     account = ask_check(
-      existing: account, message: I18n.t('message.account'), validator: Awskeyring.method(:account_exists)
+      existing: account, message: I18n.t('message.account'), validator: Awskeyring.method(:account_exists),
+      limited_to: Awskeyring.list_account_names
     )
     cred = age_check_and_get(account: account, no_token: options['no-token'])
     expiry = Time.at(cred[:expiry]) unless cred[:expiry].nil?
@@ -176,11 +177,15 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   method_option 'no-token', type: :boolean, aliases: '-n', desc: I18n.t('method_option.notoken'), default: false
   method_option 'no-bundle', type: :boolean, aliases: '-b', desc: I18n.t('method_option.nobundle'), default: false
   # execute an external command with env set
-  def exec(account, *command)
+  def exec(account, *command) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     if command.empty?
       warn I18n.t('message.exec')
       exit 1
     end
+    account = ask_check(
+      existing: account, message: I18n.t('message.account'), validator: Awskeyring.method(:account_exists),
+      limited_to: Awskeyring.list_account_names
+    )
     cred = age_check_and_get(account: account, no_token: options['no-token'])
     env_vars = Awskeyring::Awsapi.get_env_array(cred)
     unbundle if options['no-bundle']

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -322,6 +322,7 @@ unset AWS_SESSION_TOKEN
         env_vars,
         'test-exec with params'
       )
+      expect(Awskeyring).to have_received(:account_exists).with('test')
       expect(Awskeyring).to have_received(:get_valid_creds).with(account: 'test', no_token: false)
       expect(ENV['BUNDLER_ORIG_TEST_ENV']).to eq('BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL')
       expect(ENV['TEST_ENV']).to eq('CHANGED')


### PR DESCRIPTION
# Description

The EXEC command missed the validate and prefix-matching code update. this resulted in prefix only account names not being upgraded and the command failing with "Credential not found" errors.

The JSON command missed the limited_to helper too. 

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
