### PR TITLE
Add CredentialProvider class for library use.

### DIFF
--- a/lib/awskeyring.rb
+++ b/lib/awskeyring.rb
@@ -52,6 +52,7 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
     prefs = {
       awskeyring: awskeyring,
       keyage: DEFAULT_KEY_AGE,
+      browser: DEFAULT_BROWSER_LIST,
       console: DEFAULT_CONSOLE_LIST
     }
     File.new(Awskeyring::PREFS_FILE, 'w').write JSON.dump(prefs)

--- a/lib/awskeyring/credential_provider.rb
+++ b/lib/awskeyring/credential_provider.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'aws-sdk-core'
+require 'awskeyring'
+
+module Awskeyring
+  # Provide a credential provider for use as a library, eg.
+  #     require 'awskeyring/credential_provider'
+  #     client = Aws::STS::Client.new(
+  #       credentials: Awskeyring::CredentialProvider.new("company-acc")
+  #     )
+  class CredentialProvider
+    include Aws::CredentialProvider
+
+    attr_accessor :account
+
+    def initialize(account)
+      @account = account
+    end
+
+    # returns a new Aws::Credentials object
+    def credentials
+      cred = Awskeyring.get_valid_creds(account: account)
+      Aws::Credentials.new(cred[:key],
+                           cred[:secret],
+                           cred[:token])
+    end
+  end
+end

--- a/spec/lib/awskeyring/credential_provider_spec.rb
+++ b/spec/lib/awskeyring/credential_provider_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../lib/awskeyring/credential_provider'
+
+describe Awskeyring::CredentialProvider do
+  subject(:credential_provider) { described_class }
+
+  context 'when getting credentials' do
+    before do
+      allow(Awskeyring).to receive(:get_valid_creds).with(account: 'test').and_return(
+        account: 'test',
+        key: 'AKIATESTTEST',
+        secret: 'biglongbase64',
+        token: nil,
+        updated: Time.parse('2011-08-01T22:20:01Z')
+      )
+    end
+
+    it 'gets a credential_provider object' do
+      expect(credential_provider.new('test').credentials)
+        .to be_a Aws::Credentials
+    end
+  end
+end

--- a/spec/lib/awskeyring_spec.rb
+++ b/spec/lib/awskeyring_spec.rb
@@ -52,6 +52,7 @@ describe Awskeyring do
 
     it 'creates a new file' do
       expect(awskeyring.init_keychain(awskeyring: 'awskeyringtest')).to eq(write_success)
+      expect(prefs_file).to have_received(:write).with(/browser/)
     end
   end
 


### PR DESCRIPTION
# Description

Add CredentialProvider class for library use, allows ruby code to pull credentials from awskeyring and feed directly into the aws-sdk client blocks. (plus a tweak to write the default browser list into the config during init.)

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
