### PR TITLE
Stricter aws_secret validation.

### DIFF
--- a/lib/awskeyring/validate.rb
+++ b/lib/awskeyring/validate.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'base64'
+
 # Awskeyring Module,
 # gives you an interface to access keychains and items.
 module Awskeyring
@@ -27,7 +29,11 @@ module Awskeyring
     #
     # @param [String] aws_secret_access_key The aws_secret_access_key
     def self.secret_access_key(aws_secret_access_key)
-      raise 'Secret Access Key is not 40 chars' if aws_secret_access_key.length != 40
+      begin
+        raise 'Invalid Secret Access Key' unless Base64.strict_decode64(aws_secret_access_key).length == 30
+      rescue ArgumentError
+        raise 'Invalid Secret Access Key'
+      end
 
       aws_secret_access_key
     end

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "November 2021" "" ""
+.TH "AWSKEYRING" "5" "January 2022" "" ""
 .
 .SH "NAME"
 \fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain

--- a/spec/lib/awskeyring/validate_spec.rb
+++ b/spec/lib/awskeyring/validate_spec.rb
@@ -12,8 +12,8 @@ describe Awskeyring::Validate do
 
     let(:test_broken_mfa_code) { 'mfa_code' }
     let(:test_mfa_code) { '321654' }
-    let(:test_broken_secret) { 'AbCkTEsTAAAi8ni0987ASDFwer23j14FE' }
-    let(:test_secret) { 'AbCkTEsTAAAi8ni0987ASDFwer23j14FEQW3IUJV' }
+    let(:test_broken_secret) { 'hI7XqAiaR_XJxKgCqG0Wo79jm2+GcRYP' }
+    let(:test_secret) { 'vbkEXAMPLEa3TlCP2Fvmcbdp83LSaeDHtx13xc+M' }
     let(:test_broken_key) { 'AKIA1234567890' }
     let(:test_key) { 'AKIA1234567890ABCDEF' }
 
@@ -38,7 +38,7 @@ describe Awskeyring::Validate do
     end
 
     it 'invalidates an secret access key' do
-      expect { validate.secret_access_key(test_broken_secret) }.to raise_error('Secret Access Key is not 40 chars')
+      expect { validate.secret_access_key(test_broken_secret) }.to raise_error('Invalid Secret Access Key')
     end
 
     it 'validates an mfa code' do

--- a/spec/lib/awskeyring_command_more_spec.rb
+++ b/spec/lib/awskeyring_command_more_spec.rb
@@ -338,7 +338,7 @@ describe AwskeyringCommand do
     it 'tries to add an invalid secret' do
       expect do
         described_class.start(['add', 'test', '-k', access_key, '-s', bad_secret_access_key, '-m', mfa_arn])
-      end.to raise_error.and output(/Secret Access Key is not 40 chars/).to_stderr
+      end.to raise_error.and output(/Invalid Secret Access Key/).to_stderr
     end
   end
 


### PR DESCRIPTION
# Description

Improves the validation on the aws secret key to be base64 encoded string that decodes to 30 bytes. (previous was just checking the encoded length was 40)

## Did you run the Tests?

- [x] Rubocop
- [x] Rspec
- [x] Filemode
- [x] Yard
