### PR TITLE
Check for tty and allow force.

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -35,6 +35,7 @@ en:
     browser: 'Specify an alternative browser.'
     secret: 'AWS account secret.'
     unset: 'Unset environment variables.'
+    force: 'Force output to a tty.'
   message:
     keychain: 'Name for new keychain (default: awskeyring)'
     account: 'account name'
@@ -57,6 +58,7 @@ en:
     deltoken: '# Removing token for account %{account}'
     delexpired: '# Removing expired session credentials'
     exec: '# COMMAND not provided'
+    ttyblock: '# Output suppressed to a tty, --force to override'
     missing: '# Config missing, run `%{bin} initialise` to recreate.'
     missing_account: '# No accounts added, run `%{bin} add` to add.'
     missing_role: '# No roles added, run `%{bin} add-role` to add.'

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -104,11 +104,16 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   desc 'env ACCOUNT', I18n.t('env_desc')
   method_option 'no-token', type: :boolean, aliases: '-n', desc: I18n.t('method_option.notoken'), default: false
   method_option :unset, type: :boolean, aliases: '-u', desc: I18n.t('method_option.unset'), default: false
+  method_option :force, type: :boolean, aliases: '-f', desc: I18n.t('method_option.force'), default: false
   # Print Env vars
   def env(account = nil)
     if options[:unset]
       put_env_string(account: nil, key: nil, secret: nil, token: nil)
     else
+      if $stdout.isatty && !options[:force]
+        warn I18n.t('message.ttyblock')
+        exit 1
+      end
       account = ask_check(
         existing: account, message: I18n.t('message.account'),
         validator: Awskeyring.method(:account_exists),
@@ -121,8 +126,13 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
 
   desc 'json ACCOUNT', I18n.t('json_desc')
   method_option 'no-token', type: :boolean, aliases: '-n', desc: I18n.t('method_option.notoken'), default: false
+  method_option :force, type: :boolean, aliases: '-f', desc: I18n.t('method_option.force'), default: false
   # Print JSON for use with credential_process
-  def json(account)
+  def json(account) # rubocop:disable Metrics/AbcSize
+    if $stdout.isatty && !options[:force]
+      warn I18n.t('message.ttyblock')
+      exit 1
+    end
     account = ask_check(
       existing: account, message: I18n.t('message.account'), validator: Awskeyring.method(:account_exists),
       limited_to: Awskeyring.list_account_names

--- a/man/awskeyring.5
+++ b/man/awskeyring.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AWSKEYRING" "5" "October 2022" "" ""
+.TH "AWSKEYRING" "5" "November 2022" "" ""
 .
 .SH "NAME"
 \fBAwskeyring\fR \- is a small tool to manage AWS account keys in the macOS Keychain
@@ -94,6 +94,9 @@ Outputs bourne shell environment exports for an ACCOUNT
 .br
 \-u, \-\-unset, \-\-no\-unset: Unset environment variables\.
 .
+.br
+\-f, \-\-force: Force output to a tty\.
+.
 .TP
 exec ACCOUNT command\.\.\.:
 .
@@ -146,6 +149,9 @@ Outputs AWS CLI compatible JSON for an ACCOUNT
 .
 .IP
 \-n, \-\-no\-token: Do not use saved token\.
+.
+.br
+\-f, \-\-force: Force output to a tty\.
 .
 .TP
 list:

--- a/man/awskeyring.5.ronn
+++ b/man/awskeyring.5.ronn
@@ -49,7 +49,8 @@ The commands are as follows:
     Outputs bourne shell environment exports for an ACCOUNT<br>
 
     -n, --no-token: Do not use saved token.<br>
-    -u, --unset, --no-unset: Unset environment variables.
+    -u, --unset, --no-unset: Unset environment variables.<br>
+    -f, --force: Force output to a tty.
 
 * exec ACCOUNT command...:
 
@@ -78,7 +79,8 @@ The commands are as follows:
 
     Outputs AWS CLI compatible JSON for an ACCOUNT<br>
 
-    -n, --no-token: Do not use saved token.
+    -n, --no-token: Do not use saved token.<br>
+    -f, --force:    Force output to a tty.
 
 * list:
 

--- a/spec/lib/awskeyring_command_exceptional_spec.rb
+++ b/spec/lib/awskeyring_command_exceptional_spec.rb
@@ -8,6 +8,7 @@ describe AwskeyringCommand do
   context 'when everything raises an exception' do
     let(:iam_client) { instance_double(Aws::IAM::Client) }
     let(:sts_client) { instance_double(Aws::STS::Client) }
+    let(:test_tty) { instance_double(StringIO) }
 
     before do
       allow(Awskeyring).to receive(:get_valid_creds).and_return(
@@ -36,6 +37,8 @@ describe AwskeyringCommand do
                 'The security token included in the request is invalid'
               ))
       end
+      allow(test_tty).to receive(:isatty).and_return(true)
+      allow(test_tty).to receive(:write)
     end
 
     it 'fails to run an external command' do
@@ -60,6 +63,40 @@ describe AwskeyringCommand do
       expect do
         described_class.start(%w[console test])
       end.to raise_error(SystemExit).and output(/The security token included in the request is invalid/).to_stderr
+    end
+
+    it 'blocks showing JSON creds on console' do
+      old = $stdout
+      $stdout = test_tty # rubocop:disable RSpec/ExpectOutput
+      expect do
+        described_class.start(%w[json test])
+      end.to raise_error(SystemExit).and output(/Output suppressed to a tty, --force to override/).to_stderr
+      $stdout = old # rubocop:disable RSpec/ExpectOutput
+    end
+
+    it 'blocks showing creds on console' do
+      old = $stdout
+      $stdout = test_tty # rubocop:disable RSpec/ExpectOutput
+      expect do
+        described_class.start(%w[env test])
+      end.to raise_error(SystemExit).and output(/Output suppressed to a tty, --force to override/).to_stderr
+      $stdout = old # rubocop:disable RSpec/ExpectOutput
+    end
+
+    it 'allows showing creds on console' do
+      old = $stdout
+      $stdout = test_tty # rubocop:disable RSpec/ExpectOutput
+      expect { described_class.start(%w[env test --force]) }
+        .to output(%(export AWS_ACCOUNT_NAME="test"
+export AWS_ACCESS_KEY_ID="ASIATESTTEST"
+export AWS_ACCESS_KEY="ASIATESTTEST"
+export AWS_SECRET_ACCESS_KEY="bigerlongbase64"
+export AWS_SECRET_KEY="bigerlongbase64"
+unset AWS_CREDENTIAL_EXPIRATION
+unset AWS_SECURITY_TOKEN
+unset AWS_SESSION_TOKEN
+)).to_stdout
+      $stdout = old # rubocop:disable RSpec/ExpectOutput
     end
   end
 end

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -189,7 +189,7 @@ describe AwskeyringCommand do
     end
 
     it 'export an AWS Access key' do
-      expect { described_class.start(%w[env test]) }
+      expect { described_class.start(%w[env test --force]) }
         .to output(%(export AWS_DEFAULT_REGION="us-east-1"
 export AWS_ACCOUNT_NAME="test"
 export AWS_ACCESS_KEY_ID="AKIATESTTEST"


### PR DESCRIPTION
# Description

Adds a feature to suppress outputting credentials to the terminal output and show a warning. Can override with a new `--force` flag on JSON and ENV subcommands. Specifically intended to not break scripts and just warn users.

## Did you run the Tests?

- [X] Rubocop
- [X] Rspec
- [X] Filemode
- [X] Yard
